### PR TITLE
Update to SuiteSparse:GraphBLAS 5.0.3.

### DIFF
--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - graphblas=4.0.3
+  - graphblas=5.0.3
   - cffi
   - cython
   - numpy

--- a/suitesparse_graphblas/create_headers.py
+++ b/suitesparse_graphblas/create_headers.py
@@ -301,6 +301,8 @@ CHAR_DEFINES = {
 }
 
 IGNORE_DEFINES = {
+    "GrB",
+    "GxB",
     "CMPLX",
     "CMPLXF",
     "GB_PUBLIC",
@@ -311,6 +313,12 @@ IGNORE_DEFINES = {
     "NMACRO",
     # deprecated
     "GxB_HYPER",
+}
+
+IGNORE_LINES = {
+    "GxB_cuda_calloc",
+    "GxB_cuda_malloc",
+    "GxB_cuda_free",
 }
 
 
@@ -410,6 +418,23 @@ def get_groups(ast):
     groups["not seen"] = sorted(set(lines) - seen, key=sort_key)
     for group in groups["not seen"]:
         assert "extern" not in group, group
+
+    unhandled = set()
+    for line in groups["not seen"]:
+        if "GrB" in line or "GxB" in line:
+            for item in IGNORE_LINES:
+                if item in line:
+                    break
+            else:
+                unhandled.add(line)
+    if unhandled:
+        raise ValueError(
+            "\n===================================\n"
+            "Unhandled functions with GrB or GxB\n"
+            "-----------------------------------\n    "
+            + "\n    ".join(sorted(unhandled))
+            + "\n==================================="
+        )
     return groups
 
 

--- a/suitesparse_graphblas/suitesparse_graphblas.h
+++ b/suitesparse_graphblas/suitesparse_graphblas.h
@@ -104,6 +104,9 @@ typedef enum
   GxB_GLOBAL_NTHREADS = 5,
   GxB_GLOBAL_CHUNK = 7,
   GxB_BURBLE = 99,
+  GxB_PRINTF = 101,
+  GxB_FLUSH = 102,
+  GxB_MEMORY_POOL = 103,
   GxB_SPARSITY_STATUS = 33,
   GxB_SPARSITY_CONTROL = 32,
   GxB_GLOBAL_GPU_CONTROL = 21,
@@ -2844,32 +2847,35 @@ extern GrB_Info GxB_Matrix_assign_FC32(GrB_Matrix C, const GrB_Matrix Mask, cons
 extern GrB_Info GxB_Matrix_assign_FC64(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, GxB_FC64_t x, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_build_FC32(GrB_Matrix C, const GrB_Index *I, const GrB_Index *J, const GxB_FC32_t *X, GrB_Index nvals, const GrB_BinaryOp dup);
 extern GrB_Info GxB_Matrix_build_FC64(GrB_Matrix C, const GrB_Index *I, const GrB_Index *J, const GxB_FC64_t *X, GrB_Index nvals, const GrB_BinaryOp dup);
-extern GrB_Info GxB_Matrix_export_BitmapC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, GrB_Index *nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_BitmapR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, GrB_Index *nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_CSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ai_size, GrB_Index *Ax_size, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_CSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Aj_size, GrB_Index *Ax_size, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_FullC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_FullR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_HyperCSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Ai_size, GrB_Index *Ax_size, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_HyperCSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Aj_size, GrB_Index *Ax_size, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_concat(GrB_Matrix C, const GrB_Matrix *Tiles, const GrB_Index m, const GrB_Index n, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_diag(GrB_Matrix C, const GrB_Vector v, int64_t k, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_BitmapC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_BitmapR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_CSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ai_size, GrB_Index *Ax_size, bool *is_uniform, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_CSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Aj_size, GrB_Index *Ax_size, bool *is_uniform, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_FullC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, bool *is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_FullR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, bool *is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_HyperCSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Ai_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_HyperCSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Aj_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_extractElement_FC32(GxB_FC32_t *x, const GrB_Matrix A, GrB_Index i, GrB_Index j);
 extern GrB_Info GxB_Matrix_extractElement_FC64(GxB_FC64_t *x, const GrB_Matrix A, GrB_Index i, GrB_Index j);
 extern GrB_Info GxB_Matrix_extractTuples_FC32(GrB_Index *I, GrB_Index *J, GxB_FC32_t *X, GrB_Index *nvals, const GrB_Matrix A);
 extern GrB_Info GxB_Matrix_extractTuples_FC64(GrB_Index *I, GrB_Index *J, GxB_FC64_t *X, GrB_Index *nvals, const GrB_Matrix A);
 extern GrB_Info GxB_Matrix_fprint(GrB_Matrix A, const char *name, GxB_Print_Level pr, FILE *f);
-extern GrB_Info GxB_Matrix_import_BitmapC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, GrB_Index nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_BitmapR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, GrB_Index nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_CSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ai_size, GrB_Index Ax_size, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_CSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Aj_size, GrB_Index Ax_size, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_FullC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_FullR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_HyperCSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Ai_size, GrB_Index Ax_size, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_HyperCSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Aj_size, GrB_Index Ax_size, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_BitmapC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_BitmapR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_CSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ai_size, GrB_Index Ax_size, bool is_uniform, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_CSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Aj_size, GrB_Index Ax_size, bool is_uniform, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_FullC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, bool is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_FullR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, bool is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_HyperCSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Ai_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_HyperCSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Aj_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_reduce_FC32(GxB_FC32_t *c, const GrB_BinaryOp accum, const GrB_Monoid monoid, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_reduce_FC64(GxB_FC64_t *c, const GrB_BinaryOp accum, const GrB_Monoid monoid, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_select(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GxB_SelectOp op, const GrB_Matrix A, const GxB_Scalar Thunk, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_setElement_FC32(GrB_Matrix C, GxB_FC32_t x, GrB_Index i, GrB_Index j);
 extern GrB_Info GxB_Matrix_setElement_FC64(GrB_Matrix C, GxB_FC64_t x, GrB_Index i, GrB_Index j);
+extern GrB_Info GxB_Matrix_split(GrB_Matrix *Tiles, const GrB_Index m, const GrB_Index n, const GrB_Index *Tile_nrows, const GrB_Index *Tile_ncols, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_subassign(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_Matrix A, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_subassign_BOOL(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, bool x, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_subassign_FC32(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, GxB_FC32_t x, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
@@ -2887,6 +2893,7 @@ extern GrB_Info GxB_Matrix_subassign_UINT32(GrB_Matrix C, const GrB_Matrix Mask,
 extern GrB_Info GxB_Matrix_subassign_UINT64(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, uint64_t x, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_type(GrB_Type *type, const GrB_Matrix A);
 extern GrB_Info GxB_Row_subassign(GrB_Matrix C, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_Vector u, GrB_Index i, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_diag(GrB_Vector v, const GrB_Matrix A, int64_t k, const GrB_Descriptor desc);
 
 /* monoid */
 extern GrB_Info GxB_Monoid_fprint(GrB_Monoid monoid, const char *name, GxB_Print_Level pr, FILE *f);
@@ -2985,17 +2992,17 @@ extern GrB_Info GxB_Vector_assign_FC32(GrB_Vector w, const GrB_Vector mask, cons
 extern GrB_Info GxB_Vector_assign_FC64(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, GxB_FC64_t x, const GrB_Index *I, GrB_Index ni, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_build_FC32(GrB_Vector w, const GrB_Index *I, const GxB_FC32_t *X, GrB_Index nvals, const GrB_BinaryOp dup);
 extern GrB_Info GxB_Vector_build_FC64(GrB_Vector w, const GrB_Index *I, const GxB_FC64_t *X, GrB_Index nvals, const GrB_BinaryOp dup);
-extern GrB_Info GxB_Vector_export_Bitmap(GrB_Vector *v, GrB_Type *type, GrB_Index *n, int8_t **vb, void **vx, GrB_Index *vb_size, GrB_Index *vx_size, GrB_Index *nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_export_CSC(GrB_Vector *v, GrB_Type *type, GrB_Index *n, GrB_Index **vi, void **vx, GrB_Index *vi_size, GrB_Index *vx_size, GrB_Index *nvals, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_export_Full(GrB_Vector *v, GrB_Type *type, GrB_Index *n, void **vx, GrB_Index *vx_size, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_export_Bitmap(GrB_Vector *v, GrB_Type *type, GrB_Index *n, int8_t **vb, void **vx, GrB_Index *vb_size, GrB_Index *vx_size, bool *is_uniform, GrB_Index *nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_export_CSC(GrB_Vector *v, GrB_Type *type, GrB_Index *n, GrB_Index **vi, void **vx, GrB_Index *vi_size, GrB_Index *vx_size, bool *is_uniform, GrB_Index *nvals, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_export_Full(GrB_Vector *v, GrB_Type *type, GrB_Index *n, void **vx, GrB_Index *vx_size, bool *is_uniform, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_extractElement_FC32(GxB_FC32_t *x, const GrB_Vector v, GrB_Index i);
 extern GrB_Info GxB_Vector_extractElement_FC64(GxB_FC64_t *x, const GrB_Vector v, GrB_Index i);
 extern GrB_Info GxB_Vector_extractTuples_FC32(GrB_Index *I, GxB_FC32_t *X, GrB_Index *nvals, const GrB_Vector v);
 extern GrB_Info GxB_Vector_extractTuples_FC64(GrB_Index *I, GxB_FC64_t *X, GrB_Index *nvals, const GrB_Vector v);
 extern GrB_Info GxB_Vector_fprint(GrB_Vector v, const char *name, GxB_Print_Level pr, FILE *f);
-extern GrB_Info GxB_Vector_import_Bitmap(GrB_Vector *v, GrB_Type type, GrB_Index n, int8_t **vb, void **vx, GrB_Index vb_size, GrB_Index vx_size, GrB_Index nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_import_CSC(GrB_Vector *v, GrB_Type type, GrB_Index n, GrB_Index **vi, void **vx, GrB_Index vi_size, GrB_Index vx_size, GrB_Index nvals, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_import_Full(GrB_Vector *v, GrB_Type type, GrB_Index n, void **vx, GrB_Index vx_size, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_import_Bitmap(GrB_Vector *v, GrB_Type type, GrB_Index n, int8_t **vb, void **vx, GrB_Index vb_size, GrB_Index vx_size, bool is_uniform, GrB_Index nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_import_CSC(GrB_Vector *v, GrB_Type type, GrB_Index n, GrB_Index **vi, void **vx, GrB_Index vi_size, GrB_Index vx_size, bool is_uniform, GrB_Index nvals, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_import_Full(GrB_Vector *v, GrB_Type type, GrB_Index n, void **vx, GrB_Index vx_size, bool is_uniform, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_reduce_FC32(GxB_FC32_t *c, const GrB_BinaryOp accum, const GrB_Monoid monoid, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_reduce_FC64(GxB_FC64_t *c, const GrB_BinaryOp accum, const GrB_Monoid monoid, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_select(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GxB_SelectOp op, const GrB_Vector u, const GxB_Scalar Thunk, const GrB_Descriptor desc);

--- a/suitesparse_graphblas/suitesparse_graphblas_no_complex.h
+++ b/suitesparse_graphblas/suitesparse_graphblas_no_complex.h
@@ -102,6 +102,9 @@ typedef enum
   GxB_GLOBAL_NTHREADS = 5,
   GxB_GLOBAL_CHUNK = 7,
   GxB_BURBLE = 99,
+  GxB_PRINTF = 101,
+  GxB_FLUSH = 102,
+  GxB_MEMORY_POOL = 103,
   GxB_SPARSITY_STATUS = 33,
   GxB_SPARSITY_CONTROL = 32,
   GxB_GLOBAL_GPU_CONTROL = 21,
@@ -2668,24 +2671,27 @@ extern GrB_Info GxB_Matrix_Option_get(GrB_Matrix A, GxB_Option_Field field, ...)
 extern GrB_Info GxB_Matrix_Option_set(GrB_Matrix A, GxB_Option_Field field, ...);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GxB_Scalar x, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_apply_BinaryOp2nd(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Matrix A, const GxB_Scalar y, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_BitmapC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, GrB_Index *nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_BitmapR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, GrB_Index *nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_CSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ai_size, GrB_Index *Ax_size, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_CSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Aj_size, GrB_Index *Ax_size, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_FullC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_FullR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_HyperCSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Ai_size, GrB_Index *Ax_size, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_export_HyperCSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Aj_size, GrB_Index *Ax_size, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_concat(GrB_Matrix C, const GrB_Matrix *Tiles, const GrB_Index m, const GrB_Index n, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_diag(GrB_Matrix C, const GrB_Vector v, int64_t k, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_BitmapC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_BitmapR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, int8_t **Ab, void **Ax, GrB_Index *Ab_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_CSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ai_size, GrB_Index *Ax_size, bool *is_uniform, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_CSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Aj_size, GrB_Index *Ax_size, bool *is_uniform, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_FullC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, bool *is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_FullR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, void **Ax, GrB_Index *Ax_size, bool *is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_HyperCSC(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Ai_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_export_HyperCSR(GrB_Matrix *A, GrB_Type *type, GrB_Index *nrows, GrB_Index *ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index *Ap_size, GrB_Index *Ah_size, GrB_Index *Aj_size, GrB_Index *Ax_size, bool *is_uniform, GrB_Index *nvec, bool *jumbled, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_fprint(GrB_Matrix A, const char *name, GxB_Print_Level pr, FILE *f);
-extern GrB_Info GxB_Matrix_import_BitmapC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, GrB_Index nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_BitmapR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, GrB_Index nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_CSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ai_size, GrB_Index Ax_size, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_CSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Aj_size, GrB_Index Ax_size, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_FullC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_FullR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_HyperCSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Ai_size, GrB_Index Ax_size, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Matrix_import_HyperCSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Aj_size, GrB_Index Ax_size, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_BitmapC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_BitmapR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, int8_t **Ab, void **Ax, GrB_Index Ab_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_CSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ai_size, GrB_Index Ax_size, bool is_uniform, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_CSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Aj_size, GrB_Index Ax_size, bool is_uniform, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_FullC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, bool is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_FullR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, void **Ax, GrB_Index Ax_size, bool is_uniform, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_HyperCSC(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Ai, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Ai_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_import_HyperCSR(GrB_Matrix *A, GrB_Type type, GrB_Index nrows, GrB_Index ncols, GrB_Index **Ap, GrB_Index **Ah, GrB_Index **Aj, void **Ax, GrB_Index Ap_size, GrB_Index Ah_size, GrB_Index Aj_size, GrB_Index Ax_size, bool is_uniform, GrB_Index nvec, bool jumbled, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_select(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GxB_SelectOp op, const GrB_Matrix A, const GxB_Scalar Thunk, const GrB_Descriptor desc);
+extern GrB_Info GxB_Matrix_split(GrB_Matrix *Tiles, const GrB_Index m, const GrB_Index n, const GrB_Index *Tile_nrows, const GrB_Index *Tile_ncols, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_subassign(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_Matrix A, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_subassign_BOOL(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, bool x, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_subassign_FP32(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, float x, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
@@ -2701,6 +2707,7 @@ extern GrB_Info GxB_Matrix_subassign_UINT32(GrB_Matrix C, const GrB_Matrix Mask,
 extern GrB_Info GxB_Matrix_subassign_UINT64(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, uint64_t x, const GrB_Index *I, GrB_Index ni, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_type(GrB_Type *type, const GrB_Matrix A);
 extern GrB_Info GxB_Row_subassign(GrB_Matrix C, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_Vector u, GrB_Index i, const GrB_Index *J, GrB_Index nj, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_diag(GrB_Vector v, const GrB_Matrix A, int64_t k, const GrB_Descriptor desc);
 
 /* monoid */
 extern GrB_Info GxB_Monoid_fprint(GrB_Monoid monoid, const char *name, GxB_Print_Level pr, FILE *f);
@@ -2783,13 +2790,13 @@ extern GrB_Info GxB_Vector_Option_get(GrB_Vector A, GxB_Option_Field field, ...)
 extern GrB_Info GxB_Vector_Option_set(GrB_Vector A, GxB_Option_Field field, ...);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GxB_Scalar x, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_apply_BinaryOp2nd(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Vector u, const GxB_Scalar y, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_export_Bitmap(GrB_Vector *v, GrB_Type *type, GrB_Index *n, int8_t **vb, void **vx, GrB_Index *vb_size, GrB_Index *vx_size, GrB_Index *nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_export_CSC(GrB_Vector *v, GrB_Type *type, GrB_Index *n, GrB_Index **vi, void **vx, GrB_Index *vi_size, GrB_Index *vx_size, GrB_Index *nvals, bool *jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_export_Full(GrB_Vector *v, GrB_Type *type, GrB_Index *n, void **vx, GrB_Index *vx_size, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_export_Bitmap(GrB_Vector *v, GrB_Type *type, GrB_Index *n, int8_t **vb, void **vx, GrB_Index *vb_size, GrB_Index *vx_size, bool *is_uniform, GrB_Index *nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_export_CSC(GrB_Vector *v, GrB_Type *type, GrB_Index *n, GrB_Index **vi, void **vx, GrB_Index *vi_size, GrB_Index *vx_size, bool *is_uniform, GrB_Index *nvals, bool *jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_export_Full(GrB_Vector *v, GrB_Type *type, GrB_Index *n, void **vx, GrB_Index *vx_size, bool *is_uniform, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_fprint(GrB_Vector v, const char *name, GxB_Print_Level pr, FILE *f);
-extern GrB_Info GxB_Vector_import_Bitmap(GrB_Vector *v, GrB_Type type, GrB_Index n, int8_t **vb, void **vx, GrB_Index vb_size, GrB_Index vx_size, GrB_Index nvals, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_import_CSC(GrB_Vector *v, GrB_Type type, GrB_Index n, GrB_Index **vi, void **vx, GrB_Index vi_size, GrB_Index vx_size, GrB_Index nvals, bool jumbled, const GrB_Descriptor desc);
-extern GrB_Info GxB_Vector_import_Full(GrB_Vector *v, GrB_Type type, GrB_Index n, void **vx, GrB_Index vx_size, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_import_Bitmap(GrB_Vector *v, GrB_Type type, GrB_Index n, int8_t **vb, void **vx, GrB_Index vb_size, GrB_Index vx_size, bool is_uniform, GrB_Index nvals, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_import_CSC(GrB_Vector *v, GrB_Type type, GrB_Index n, GrB_Index **vi, void **vx, GrB_Index vi_size, GrB_Index vx_size, bool is_uniform, GrB_Index nvals, bool jumbled, const GrB_Descriptor desc);
+extern GrB_Info GxB_Vector_import_Full(GrB_Vector *v, GrB_Type type, GrB_Index n, void **vx, GrB_Index vx_size, bool is_uniform, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_select(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GxB_SelectOp op, const GrB_Vector u, const GxB_Scalar Thunk, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_subassign(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_Vector u, const GrB_Index *I, GrB_Index ni, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_subassign_BOOL(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, bool x, const GrB_Index *I, GrB_Index ni, const GrB_Descriptor desc);


### PR DESCRIPTION
Also, add sanity check to make sure all GrB and GxB lines are handled.
This would have caught the issue of the new functions not being public in v5.0.2.

This is actually a pretty nice way to see the changes between versions!

The conda-forge build for SuiteSparse:GraphBLAS v5.0.3 is in progress.