### PR TITLE
Fix version regex when building wheels

### DIFF
--- a/suitesparse.sh
+++ b/suitesparse.sh
@@ -1,10 +1,11 @@
 
-if [[ $1 =~ refs/tags/([0-9]\.[0-9]\.[0-9]).*$ ]];
+if [[ $1 =~ refs/tags/([0-9]*\.[0-9]*\.[0-9]*)\..*$ ]];
 then
     VERSION=${BASH_REMATCH[1]}
 else
     exit -1
 fi
+echo VERSION: $VERSION
 
 curl -L https://github.com/DrTimothyAldenDavis/GraphBLAS/archive/refs/tags/v${VERSION}.tar.gz | tar xzf -
 cd GraphBLAS-${VERSION}/build


### PR DESCRIPTION
It matched `5.1.1` instead of `5.1.10` here:

https://github.com/GraphBLAS/python-suitesparse-graphblas/runs/4052889018?check_suite_focus=true#step:4:30