### PR TITLE
Fix issue with `Scalar_setElement_FC64` with cffi voodoo magic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: GraphBLAS (from conda-forge)
       if: (contains(matrix.source, 'conda-forge'))
       run: |
-        conda install -c conda-forge graphblas=${{ matrix.graphblas-version }}
+        conda install -c conda-forge graphblas=${{ matrix.graphblas-version }} pytest pytest-randomly
     - name: GraphBLAS (from source)
       if: (contains(matrix.source, 'source'))
       run: |

--- a/suitesparse_graphblas/__init__.py
+++ b/suitesparse_graphblas/__init__.py
@@ -44,6 +44,9 @@ def initialize(*, blocking=False, memory_manager="numpy"):
         lib.GrB_init(blocking)
     else:
         raise ValueError(f'memory_manager argument must be "numpy" or "c"; got: {memory_manager!r}')
+    # See: https://github.com/GraphBLAS/python-suitesparse-graphblas/issues/40
+    for attr in dir(lib):
+        getattr(lib, attr)
 
 
 def libget(name):

--- a/suitesparse_graphblas/tests/test_scalar.py
+++ b/suitesparse_graphblas/tests/test_scalar.py
@@ -4,6 +4,6 @@ from suitesparse_graphblas import ffi, lib
 def test_complex():
     s = ffi.new("GrB_Scalar*")
     success = lib.GrB_SUCCESS
-    assert lib.GrB_Scalar_new(s, ssgb.lib.GxB_FC64) == success
+    assert lib.GrB_Scalar_new(s, lib.GxB_FC64) == success
     assert lib.GxB_Scalar_setElement_FC64(s[0], 1j) == success
     assert lib.GrB_Scalar_free(s) == success

--- a/suitesparse_graphblas/tests/test_scalar.py
+++ b/suitesparse_graphblas/tests/test_scalar.py
@@ -1,6 +1,9 @@
-from suitesparse_graphblas import ffi, lib
+import pytest
+
+from suitesparse_graphblas import ffi, lib, supports_complex  # noqa
 
 
+@pytest.mark.skipif("not supports_complex()")
 def test_complex():
     s = ffi.new("GrB_Scalar*")
     success = lib.GrB_SUCCESS

--- a/suitesparse_graphblas/tests/test_scalar.py
+++ b/suitesparse_graphblas/tests/test_scalar.py
@@ -1,0 +1,9 @@
+from suitesparse_graphblas import ffi, lib
+
+
+def test_complex():
+    s = ffi.new("GrB_Scalar*")
+    success = lib.GrB_SUCCESS
+    assert lib.GrB_Scalar_new(s, ssgb.lib.GxB_FC64) == success
+    assert lib.GxB_Scalar_setElement_FC64(s[0], 1j) == success
+    assert lib.GrB_Scalar_free(s) == success

--- a/suitesparse_graphblas/utils.pxd
+++ b/suitesparse_graphblas/utils.pxd
@@ -1,5 +1,6 @@
 from libc.stdint cimport uint64_t
-from numpy cimport ndarray, npy_intp, dtype as dtype_t
+from numpy cimport dtype as dtype_t
+from numpy cimport ndarray, npy_intp
 
 
 cdef extern from "numpy/arrayobject.h" nogil:

--- a/suitesparse_graphblas/utils.pyx
+++ b/suitesparse_graphblas/utils.pyx
@@ -1,15 +1,9 @@
 import numpy as np
 from cpython.ref cimport Py_INCREF
 from libc.stdint cimport uintptr_t
-from numpy cimport (
-    NPY_ARRAY_F_CONTIGUOUS,
-    NPY_ARRAY_OWNDATA,
-    NPY_ARRAY_WRITEABLE,
-    import_array,
-    ndarray,
-    npy_intp,
-    dtype as dtype_t,
-)
+from numpy cimport NPY_ARRAY_F_CONTIGUOUS, NPY_ARRAY_OWNDATA, NPY_ARRAY_WRITEABLE
+from numpy cimport dtype as dtype_t
+from numpy cimport import_array, ndarray, npy_intp
 
 import_array()
 
@@ -58,6 +52,7 @@ cpdef ndarray claim_buffer_2d(
         dims[1] = ncols
         if not is_c_order:
             flags |= NPY_ARRAY_F_CONTIGUOUS
+        Py_INCREF(dtype)
         array = PyArray_NewFromDescr(
             ndarray, dtype, 2, dims, NULL, <void*>ptr, flags, <object>NULL
         )


### PR DESCRIPTION
Fixes #40 (probably)
Also, run tests randomly to ensure robustness.
Also, I think I forgot an incref in a previous PR, so I'm adding now.  It's possible not having this would result in _other_ mysterious segfaults when using user-defined types.