### PR TITLE
Add helper functions to enable and disable BURBLE to print diagnostics.

### DIFF
--- a/suitesparse_graphblas/__init__.py
+++ b/suitesparse_graphblas/__init__.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager as _contextmanager
+
 from . import _version
 from . import exceptions as ex
 from . import utils
@@ -173,6 +175,39 @@ def check_status(obj, response_code):
     error_func(string, obj)
     text = ffi.string(string[0]).decode()
     raise _error_code_lookup[response_code](text)
+
+
+def enable_burble():
+    """Enable diagnostic output"""
+    info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, ffi.cast("int", 1))
+    if info != lib.GrB_SUCCESS:
+        raise _error_code_lookup[info]("Failed to enable burble (has GraphBLAS been initialized?")
+
+
+def disable_burble():
+    """Disable diagnostic output"""
+    info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, ffi.cast("int", 0))
+    if info != lib.GrB_SUCCESS:
+        raise _error_code_lookup[info]("Failed to disable burble (has GraphBLAS been initialized?")
+
+
+@_contextmanager
+def burbling():
+    """Enable diagnostic output within a context.
+
+    >>> from suitesparse_graphblas import burbling, lib, matrix
+    >>>
+    >>> A = matrix.new(lib.GrB_BOOL, 3, 3)
+    >>> with burbling():
+    >>>     n = matrix.nvals(A)
+      [ GrB_Matrix_nvals
+         1.91e-06 sec ]
+    """
+    enable_burble()
+    try:
+        yield
+    finally:
+        disable_burble()
 
 
 __version__ = _version.get_versions()["version"]

--- a/suitesparse_graphblas/__init__.py
+++ b/suitesparse_graphblas/__init__.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager as _contextmanager
-
 from . import _version
 from . import exceptions as ex
 from . import utils
@@ -177,37 +175,88 @@ def check_status(obj, response_code):
     raise _error_code_lookup[response_code](text)
 
 
-def enable_burble():
-    """Enable diagnostic output"""
-    info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, ffi.cast("int", 1))
-    if info != lib.GrB_SUCCESS:
-        raise _error_code_lookup[info]("Failed to enable burble (has GraphBLAS been initialized?")
+class burble:
+    """Control diagnostic output, and may be used as a context manager.
 
+    Set up and simple usage:
 
-def disable_burble():
-    """Disable diagnostic output"""
-    info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, ffi.cast("int", 0))
-    if info != lib.GrB_SUCCESS:
-        raise _error_code_lookup[info]("Failed to disable burble (has GraphBLAS been initialized?")
-
-
-@_contextmanager
-def burbling():
-    """Enable diagnostic output within a context.
-
-    >>> from suitesparse_graphblas import burbling, lib, matrix
+    >>> from suitesparse_graphblas import burble, lib, matrix
     >>>
     >>> A = matrix.new(lib.GrB_BOOL, 3, 3)
-    >>> with burbling():
+    >>> burble.is_enabled
+    False
+    >>> burble.enable()
+    >>> burble.is_enabled
+    True
+    >>> burble.disable()
+
+    Example with explicit enable and disable:
+
+    >>> burble.enable()
+    >>> n = matrix.nvals(A)
+      [ GrB_Matrix_nvals
+         1.91e-06 sec ]
+    >>> burble.disable()
+
+    Example as a context manager:
+
+    >>> with burble():
     >>>     n = matrix.nvals(A)
       [ GrB_Matrix_nvals
          1.91e-06 sec ]
+
     """
-    enable_burble()
-    try:
-        yield
-    finally:
-        disable_burble()
+
+    def __init__(self):
+        self._states = []
+
+    @property
+    def is_enabled(self):
+        """Is burble enabled?"""
+        val_ptr = ffi.new("bool*")
+        info = lib.GxB_Global_Option_get(lib.GxB_BURBLE, val_ptr)
+        if info != lib.GrB_SUCCESS:
+            raise _error_code_lookup[info](
+                "Failed to get burble status (has GraphBLAS been initialized?"
+            )
+        return val_ptr[0]
+
+    def enable(self):
+        """Enable diagnostic output"""
+        info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, ffi.cast("int", 1))
+        if info != lib.GrB_SUCCESS:
+            raise _error_code_lookup[info](
+                "Failed to enable burble (has GraphBLAS been initialized?"
+            )
+
+    def disable(self):
+        """Disable diagnostic output"""
+        info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, ffi.cast("int", 0))
+        if info != lib.GrB_SUCCESS:
+            raise _error_code_lookup[info](
+                "Failed to disable burble (has GraphBLAS been initialized?"
+            )
+
+    def __enter__(self):
+        is_enabled = self.is_enabled
+        if not is_enabled:
+            self.enable()
+        self._states.append(is_enabled)
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        is_enabled = self._states.pop()
+        if not is_enabled:
+            self.disable()
+
+    def __reduce__(self):
+        return "burble"
+
+    def __repr__(self):
+        return f"<burble is_enabled={self.is_enabled}>"
+
+
+burble = burble()
 
 
 __version__ = _version.get_versions()["version"]


### PR DESCRIPTION
Adds `enable_burble` and `disable_burble`.  I want approval before merging this.  Heh, I couldn't help myself: `burbling` is too fun a name to pass up!

We could also have this as e.g.
```python
>>> from suitesparse_graphblas import burble
>>> burble.enable()
>>> # Do stuff
>>> burble.disable()
>>> with burble:
...     # Do some more stuff
```
Is it worth it as a context manager?  Should it _restore_ to the previous value or GxB_BURBLE instead of disabling it?