### PR TITLE
SuiteSparse:GraphBLAS v740 branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        # source: ["conda-forge"]
-        os: ["ubuntu-latest"]
-        source: ["source"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        source: ["conda-forge"]
+        # os: ["ubuntu-latest"]
+        # source: ["source"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        graphblas-version: ["7.4.0.beta1"]
+        graphblas-version: ["7.4.0"]
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        source: ["conda-forge"]
-        # os: ["ubuntu-latest"]
-        # source: ["source"]
+        # os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        # source: ["conda-forge"]
+        os: ["ubuntu-latest"]
+        source: ["source"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        graphblas-version: ["7.3.3"]
+        graphblas-version: ["7.4.0.beta1"]
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/suitesparse_graphblas/__init__.py
+++ b/suitesparse_graphblas/__init__.py
@@ -12,6 +12,9 @@ _c_float = ffi.typeof("float")
 _c_double = ffi.typeof("double")
 
 
+# It is strongly recommended to use the non-variadic version of functions to be
+# compatible with the most number of architectures. For example, you should use
+# GxB_Matrix_Option_get_INT32 instead of GxB_Matrix_Option_get.
 if _is_osx_arm64 or _is_ppc64le:
 
     def vararg(val):
@@ -38,8 +41,8 @@ else:
 
 def is_initialized():
     """Is GraphBLAS initialized via GrB_init or GxB_init?"""
-    mode = ffi.new("GrB_Mode*")
-    return lib.GxB_Global_Option_get(lib.GxB_MODE, vararg(mode)) != lib.GrB_PANIC
+    mode = ffi.new("int32_t*")
+    return lib.GxB_Global_Option_get_INT32(lib.GxB_MODE, mode) != lib.GrB_PANIC
 
 
 def supports_complex():
@@ -246,8 +249,8 @@ class burble:
     @property
     def is_enabled(self):
         """Is burble enabled?"""
-        val_ptr = ffi.new("bool*")
-        info = lib.GxB_Global_Option_get(lib.GxB_BURBLE, vararg(val_ptr))
+        val_ptr = ffi.new("int32_t*")
+        info = lib.GxB_Global_Option_get_INT32(lib.GxB_BURBLE, val_ptr)
         if info != lib.GrB_SUCCESS:
             raise _error_code_lookup[info](
                 "Failed to get burble status (has GraphBLAS been initialized?"
@@ -256,7 +259,7 @@ class burble:
 
     def enable(self):
         """Enable diagnostic output"""
-        info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, vararg(ffi.cast("int", 1)))
+        info = lib.GxB_Global_Option_set_INT32(lib.GxB_BURBLE, ffi.cast("int32_t", 1))
         if info != lib.GrB_SUCCESS:
             raise _error_code_lookup[info](
                 "Failed to enable burble (has GraphBLAS been initialized?"
@@ -264,7 +267,7 @@ class burble:
 
     def disable(self):
         """Disable diagnostic output"""
-        info = lib.GxB_Global_Option_set(lib.GxB_BURBLE, vararg(ffi.cast("int", 0)))
+        info = lib.GxB_Global_Option_set_INT32(lib.GxB_BURBLE, ffi.cast("int32_t", 0))
         if info != lib.GrB_SUCCESS:
             raise _error_code_lookup[info](
                 "Failed to disable burble (has GraphBLAS been initialized?"

--- a/suitesparse_graphblas/io/serialize.py
+++ b/suitesparse_graphblas/io/serialize.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from suitesparse_graphblas import check_status, ffi, lib, vararg
+from suitesparse_graphblas import check_status, ffi, lib
 from suitesparse_graphblas.utils import claim_buffer
 
 
@@ -22,7 +22,7 @@ def get_serialize_desc(compression=lib.GxB_COMPRESSION_DEFAULT, level=None, nthr
     if nthreads is not None:
         check_status(
             desc,
-            lib.GxB_Desc_set(desc[0], lib.GxB_NTHREADS, vararg(ffi.cast("int", nthreads))),
+            lib.GxB_Desc_set_INT32(desc[0], lib.GxB_NTHREADS, ffi.cast("int32_t", nthreads)),
         )
     if compression is not None:
         if level is not None and compression in {
@@ -32,7 +32,7 @@ def get_serialize_desc(compression=lib.GxB_COMPRESSION_DEFAULT, level=None, nthr
             compression += level
         check_status(
             desc,
-            lib.GxB_Desc_set(desc[0], lib.GxB_COMPRESSION, vararg(ffi.cast("int", compression))),
+            lib.GxB_Desc_set_INT32(desc[0], lib.GxB_COMPRESSION, ffi.cast("int32_t", compression)),
         )
     return desc
 

--- a/suitesparse_graphblas/matrix.py
+++ b/suitesparse_graphblas/matrix.py
@@ -129,9 +129,7 @@ def set_format(A, format):
 def sparsity_status(A):
     """Get the sparsity status of the matrix."""
     sparsity_status = ffi.new("int32_t*")
-    check_status(
-        A, lib.GxB_Matrix_Option_get_INT32(A[0], lib.GxB_SPARSITY_STATUS, sparsity_status)
-    )
+    check_status(A, lib.GxB_Matrix_Option_get_INT32(A[0], lib.GxB_SPARSITY_STATUS, sparsity_status))
     return sparsity_status[0]
 
 

--- a/suitesparse_graphblas/matrix.py
+++ b/suitesparse_graphblas/matrix.py
@@ -1,4 +1,4 @@
-from suitesparse_graphblas import check_status, ffi, lib, vararg
+from suitesparse_graphblas import check_status, ffi, lib
 
 from .io.serialize import deserialize_matrix as deserialize  # noqa
 from .io.serialize import serialize_matrix as serialize  # noqa
@@ -108,8 +108,8 @@ def format(A):
     True
 
     """
-    format = ffi.new("GxB_Format_Value*")
-    check_status(A, lib.GxB_Matrix_Option_get(A[0], lib.GxB_FORMAT, vararg(format)))
+    format = ffi.new("int32_t*")
+    check_status(A, lib.GxB_Matrix_Option_get_INT32(A[0], lib.GxB_FORMAT, format))
     return format[0]
 
 
@@ -122,15 +122,15 @@ def set_format(A, format):
     True
 
     """
-    format_val = ffi.cast("GxB_Format_Value", format)
-    check_status(A, lib.GxB_Matrix_Option_set(A[0], lib.GxB_FORMAT, vararg(format_val)))
+    format_val = ffi.cast("int32_t", format)
+    check_status(A, lib.GxB_Matrix_Option_set_INT32(A[0], lib.GxB_FORMAT, format_val))
 
 
 def sparsity_status(A):
     """Get the sparsity status of the matrix."""
     sparsity_status = ffi.new("int32_t*")
     check_status(
-        A, lib.GxB_Matrix_Option_get(A[0], lib.GxB_SPARSITY_STATUS, vararg(sparsity_status))
+        A, lib.GxB_Matrix_Option_get_INT32(A[0], lib.GxB_SPARSITY_STATUS, sparsity_status)
     )
     return sparsity_status[0]
 
@@ -139,7 +139,7 @@ def sparsity_control(A):
     """Get the sparsity control of the matrix."""
     sparsity_control = ffi.new("int32_t*")
     check_status(
-        A, lib.GxB_Matrix_Option_get(A[0], lib.GxB_SPARSITY_CONTROL, vararg(sparsity_control))
+        A, lib.GxB_Matrix_Option_get_INT32(A[0], lib.GxB_SPARSITY_CONTROL, sparsity_control)
     )
     return sparsity_control[0]
 
@@ -148,34 +148,34 @@ def set_sparsity_control(A, sparsity):
     """Set the sparsity control of the matrix."""
     sparsity_control = ffi.cast("int32_t", sparsity)
     check_status(
-        A, lib.GxB_Matrix_Option_set(A[0], lib.GxB_SPARSITY_CONTROL, vararg(sparsity_control))
+        A, lib.GxB_Matrix_Option_set_INT32(A[0], lib.GxB_SPARSITY_CONTROL, sparsity_control)
     )
 
 
 def hyper_switch(A):
     """Get the hyper switch of the matrix."""
     hyper_switch = ffi.new("double*")
-    check_status(A, lib.GxB_Matrix_Option_get(A[0], lib.GxB_HYPER_SWITCH, vararg(hyper_switch)))
+    check_status(A, lib.GxB_Matrix_Option_get_FP64(A[0], lib.GxB_HYPER_SWITCH, hyper_switch))
     return hyper_switch[0]
 
 
 def set_hyper_switch(A, hyper_switch):
     """Set the hyper switch of the matrix."""
     hyper_switch = ffi.cast("double", hyper_switch)
-    check_status(A, lib.GxB_Matrix_Option_set(A[0], lib.GxB_HYPER_SWITCH, vararg(hyper_switch)))
+    check_status(A, lib.GxB_Matrix_Option_set_FP64(A[0], lib.GxB_HYPER_SWITCH, hyper_switch))
 
 
 def bitmap_switch(A):
     """Get the bitmap switch of the matrix."""
     bitmap_switch = ffi.new("double*")
-    check_status(A, lib.GxB_Matrix_Option_get(A[0], lib.GxB_BITMAP_SWITCH, vararg(bitmap_switch)))
+    check_status(A, lib.GxB_Matrix_Option_get_FP64(A[0], lib.GxB_BITMAP_SWITCH, bitmap_switch))
     return bitmap_switch[0]
 
 
 def set_bitmap_switch(A, bitmap_switch):
     """Set the bitmap switch of the matrix."""
     bitmap_switch = ffi.cast("double", bitmap_switch)
-    check_status(A, lib.GxB_Matrix_Option_set(A[0], lib.GxB_BITMAP_SWITCH, vararg(bitmap_switch)))
+    check_status(A, lib.GxB_Matrix_Option_set_FP64(A[0], lib.GxB_BITMAP_SWITCH, bitmap_switch))
 
 
 def set_bool(A, value, i, j):

--- a/suitesparse_graphblas/suitesparse_graphblas.h
+++ b/suitesparse_graphblas/suitesparse_graphblas.h
@@ -3115,7 +3115,11 @@ extern GrB_Info GxB_init(GrB_Mode mode, void *(*user_malloc_function)(size_t), v
 
 /* descriptor */
 extern GrB_Info GxB_Desc_get(GrB_Descriptor desc, GrB_Desc_Field field, ...);
+extern GrB_Info GxB_Desc_get_FP64(GrB_Descriptor desc, GrB_Desc_Field field, double *value);
+extern GrB_Info GxB_Desc_get_INT32(GrB_Descriptor desc, GrB_Desc_Field field, int32_t *value);
 extern GrB_Info GxB_Desc_set(GrB_Descriptor desc, GrB_Desc_Field field, ...);
+extern GrB_Info GxB_Desc_set_FP64(GrB_Descriptor desc, GrB_Desc_Field field, double value);
+extern GrB_Info GxB_Desc_set_INT32(GrB_Descriptor desc, GrB_Desc_Field field, int32_t value);
 extern GrB_Info GxB_Descriptor_fprint(GrB_Descriptor descriptor, const char *name, GxB_Print_Level pr, FILE *f);
 extern GrB_Info GxB_Descriptor_get(GrB_Desc_Value *val, GrB_Descriptor desc, GrB_Desc_Field field);
 
@@ -3172,7 +3176,11 @@ extern void GxB_Matrix_Iterator_getIndex(GxB_Iterator iterator, GrB_Index *row, 
 extern GrB_Info GxB_Col_subassign(GrB_Matrix C, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_Vector u, const GrB_Index *I, GrB_Index ni, GrB_Index j, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_Iterator_attach(GxB_Iterator iterator, GrB_Matrix A, GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_Option_get(GrB_Matrix A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Matrix_Option_get_FP64(GrB_Matrix A, GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Matrix_Option_get_INT32(GrB_Matrix A, GxB_Option_Field field, int32_t *value);
 extern GrB_Info GxB_Matrix_Option_set(GrB_Matrix A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Matrix_Option_set_FP64(GrB_Matrix A, GxB_Option_Field field, double value);
+extern GrB_Info GxB_Matrix_Option_set_INT32(GrB_Matrix A, GxB_Option_Field field, int32_t value);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Scalar x, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st_FC32(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC32_t x, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st_FC64(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC64_t x, const GrB_Matrix A, const GrB_Descriptor desc);
@@ -3366,7 +3374,11 @@ extern GrB_Info GxB_UnaryOp_ztype_name(char *type_name, const GrB_UnaryOp unaryo
 /* vector */
 extern GrB_Info GxB_Vector_Iterator_attach(GxB_Iterator iterator, GrB_Vector v, GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_Option_get(GrB_Vector A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Vector_Option_get_FP64(GrB_Vector v, GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Vector_Option_get_INT32(GrB_Vector v, GxB_Option_Field field, int32_t *value);
 extern GrB_Info GxB_Vector_Option_set(GrB_Vector A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Vector_Option_set_FP64(GrB_Vector v, GxB_Option_Field field, double value);
+extern GrB_Info GxB_Vector_Option_set_INT32(GrB_Vector v, GxB_Option_Field field, int32_t value);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Scalar x, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st_FC32(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC32_t x, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st_FC64(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC64_t x, const GrB_Vector u, const GrB_Descriptor desc);

--- a/suitesparse_graphblas/suitesparse_graphblas.h
+++ b/suitesparse_graphblas/suitesparse_graphblas.h
@@ -3099,7 +3099,17 @@ extern GrB_Info GxB_BinaryOp_ztype_name(char *type_name, const GrB_BinaryOp bina
 
 /* core */
 extern GrB_Info GxB_Global_Option_get(GxB_Option_Field field, ...);
+extern GrB_Info GxB_Global_Option_get_CHAR(GxB_Option_Field field, char **value);
+extern GrB_Info GxB_Global_Option_get_FP64(GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Global_Option_get_FUNCTION(GxB_Option_Field field, void **value);
+extern GrB_Info GxB_Global_Option_get_INT32(GxB_Option_Field field, int32_t *value);
+extern GrB_Info GxB_Global_Option_get_INT64(GxB_Option_Field field, int64_t *value);
 extern GrB_Info GxB_Global_Option_set(GxB_Option_Field field, ...);
+extern GrB_Info GxB_Global_Option_set_FP64(GxB_Option_Field field, double value);
+extern GrB_Info GxB_Global_Option_set_FP64_ARRAY(GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Global_Option_set_FUNCTION(GxB_Option_Field field, void *value);
+extern GrB_Info GxB_Global_Option_set_INT32(GxB_Option_Field field, int32_t value);
+extern GrB_Info GxB_Global_Option_set_INT64_ARRAY(GxB_Option_Field field, int64_t *value);
 extern GrB_Info GxB_deserialize_type_name(char *type_name, const void *blob, GrB_Index blob_size);
 extern GrB_Info GxB_init(GrB_Mode mode, void *(*user_malloc_function)(size_t), void *(*user_calloc_function)(size_t, size_t), void *(*user_realloc_function)(void *, size_t), void (*user_free_function)(void *));
 

--- a/suitesparse_graphblas/suitesparse_graphblas_arm64.h
+++ b/suitesparse_graphblas/suitesparse_graphblas_arm64.h
@@ -3099,7 +3099,17 @@ extern GrB_Info GxB_BinaryOp_ztype_name(char *type_name, const GrB_BinaryOp bina
 
 /* core */
 extern GrB_Info GxB_Global_Option_get(GxB_Option_Field field, char *);
+extern GrB_Info GxB_Global_Option_get_CHAR(GxB_Option_Field field, char **value);
+extern GrB_Info GxB_Global_Option_get_FP64(GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Global_Option_get_FUNCTION(GxB_Option_Field field, void **value);
+extern GrB_Info GxB_Global_Option_get_INT32(GxB_Option_Field field, int32_t *value);
+extern GrB_Info GxB_Global_Option_get_INT64(GxB_Option_Field field, int64_t *value);
 extern GrB_Info GxB_Global_Option_set(GxB_Option_Field field, char *);
+extern GrB_Info GxB_Global_Option_set_FP64(GxB_Option_Field field, double value);
+extern GrB_Info GxB_Global_Option_set_FP64_ARRAY(GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Global_Option_set_FUNCTION(GxB_Option_Field field, void *value);
+extern GrB_Info GxB_Global_Option_set_INT32(GxB_Option_Field field, int32_t value);
+extern GrB_Info GxB_Global_Option_set_INT64_ARRAY(GxB_Option_Field field, int64_t *value);
 extern GrB_Info GxB_deserialize_type_name(char *type_name, const void *blob, GrB_Index blob_size);
 extern GrB_Info GxB_init(GrB_Mode mode, void *(*user_malloc_function)(size_t), void *(*user_calloc_function)(size_t, size_t), void *(*user_realloc_function)(void *, size_t), void (*user_free_function)(void *));
 

--- a/suitesparse_graphblas/suitesparse_graphblas_arm64.h
+++ b/suitesparse_graphblas/suitesparse_graphblas_arm64.h
@@ -3115,7 +3115,11 @@ extern GrB_Info GxB_init(GrB_Mode mode, void *(*user_malloc_function)(size_t), v
 
 /* descriptor */
 extern GrB_Info GxB_Desc_get(GrB_Descriptor desc, GrB_Desc_Field field, char *);
+extern GrB_Info GxB_Desc_get_FP64(GrB_Descriptor desc, GrB_Desc_Field field, double *value);
+extern GrB_Info GxB_Desc_get_INT32(GrB_Descriptor desc, GrB_Desc_Field field, int32_t *value);
 extern GrB_Info GxB_Desc_set(GrB_Descriptor desc, GrB_Desc_Field field, char *);
+extern GrB_Info GxB_Desc_set_FP64(GrB_Descriptor desc, GrB_Desc_Field field, double value);
+extern GrB_Info GxB_Desc_set_INT32(GrB_Descriptor desc, GrB_Desc_Field field, int32_t value);
 extern GrB_Info GxB_Descriptor_fprint(GrB_Descriptor descriptor, const char *name, GxB_Print_Level pr, FILE *f);
 extern GrB_Info GxB_Descriptor_get(GrB_Desc_Value *val, GrB_Descriptor desc, GrB_Desc_Field field);
 
@@ -3172,7 +3176,11 @@ extern void GxB_Matrix_Iterator_getIndex(GxB_Iterator iterator, GrB_Index *row, 
 extern GrB_Info GxB_Col_subassign(GrB_Matrix C, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_Vector u, const GrB_Index *I, GrB_Index ni, GrB_Index j, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_Iterator_attach(GxB_Iterator iterator, GrB_Matrix A, GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_Option_get(GrB_Matrix A, GxB_Option_Field field, char *);
+extern GrB_Info GxB_Matrix_Option_get_FP64(GrB_Matrix A, GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Matrix_Option_get_INT32(GrB_Matrix A, GxB_Option_Field field, int32_t *value);
 extern GrB_Info GxB_Matrix_Option_set(GrB_Matrix A, GxB_Option_Field field, char *);
+extern GrB_Info GxB_Matrix_Option_set_FP64(GrB_Matrix A, GxB_Option_Field field, double value);
+extern GrB_Info GxB_Matrix_Option_set_INT32(GrB_Matrix A, GxB_Option_Field field, int32_t value);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Scalar x, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st_FC32(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC32_t x, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st_FC64(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC64_t x, const GrB_Matrix A, const GrB_Descriptor desc);
@@ -3366,7 +3374,11 @@ extern GrB_Info GxB_UnaryOp_ztype_name(char *type_name, const GrB_UnaryOp unaryo
 /* vector */
 extern GrB_Info GxB_Vector_Iterator_attach(GxB_Iterator iterator, GrB_Vector v, GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_Option_get(GrB_Vector A, GxB_Option_Field field, char *);
+extern GrB_Info GxB_Vector_Option_get_FP64(GrB_Vector v, GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Vector_Option_get_INT32(GrB_Vector v, GxB_Option_Field field, int32_t *value);
 extern GrB_Info GxB_Vector_Option_set(GrB_Vector A, GxB_Option_Field field, char *);
+extern GrB_Info GxB_Vector_Option_set_FP64(GrB_Vector v, GxB_Option_Field field, double value);
+extern GrB_Info GxB_Vector_Option_set_INT32(GrB_Vector v, GxB_Option_Field field, int32_t value);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Scalar x, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st_FC32(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC32_t x, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st_FC64(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, GxB_FC64_t x, const GrB_Vector u, const GrB_Descriptor desc);

--- a/suitesparse_graphblas/suitesparse_graphblas_no_complex.h
+++ b/suitesparse_graphblas/suitesparse_graphblas_no_complex.h
@@ -2925,7 +2925,17 @@ extern GrB_Info GxB_BinaryOp_ztype_name(char *type_name, const GrB_BinaryOp bina
 
 /* core */
 extern GrB_Info GxB_Global_Option_get(GxB_Option_Field field, ...);
+extern GrB_Info GxB_Global_Option_get_CHAR(GxB_Option_Field field, char **value);
+extern GrB_Info GxB_Global_Option_get_FP64(GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Global_Option_get_FUNCTION(GxB_Option_Field field, void **value);
+extern GrB_Info GxB_Global_Option_get_INT32(GxB_Option_Field field, int32_t *value);
+extern GrB_Info GxB_Global_Option_get_INT64(GxB_Option_Field field, int64_t *value);
 extern GrB_Info GxB_Global_Option_set(GxB_Option_Field field, ...);
+extern GrB_Info GxB_Global_Option_set_FP64(GxB_Option_Field field, double value);
+extern GrB_Info GxB_Global_Option_set_FP64_ARRAY(GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Global_Option_set_FUNCTION(GxB_Option_Field field, void *value);
+extern GrB_Info GxB_Global_Option_set_INT32(GxB_Option_Field field, int32_t value);
+extern GrB_Info GxB_Global_Option_set_INT64_ARRAY(GxB_Option_Field field, int64_t *value);
 extern GrB_Info GxB_deserialize_type_name(char *type_name, const void *blob, GrB_Index blob_size);
 extern GrB_Info GxB_init(GrB_Mode mode, void *(*user_malloc_function)(size_t), void *(*user_calloc_function)(size_t, size_t), void *(*user_realloc_function)(void *, size_t), void (*user_free_function)(void *));
 

--- a/suitesparse_graphblas/suitesparse_graphblas_no_complex.h
+++ b/suitesparse_graphblas/suitesparse_graphblas_no_complex.h
@@ -2941,7 +2941,11 @@ extern GrB_Info GxB_init(GrB_Mode mode, void *(*user_malloc_function)(size_t), v
 
 /* descriptor */
 extern GrB_Info GxB_Desc_get(GrB_Descriptor desc, GrB_Desc_Field field, ...);
+extern GrB_Info GxB_Desc_get_FP64(GrB_Descriptor desc, GrB_Desc_Field field, double *value);
+extern GrB_Info GxB_Desc_get_INT32(GrB_Descriptor desc, GrB_Desc_Field field, int32_t *value);
 extern GrB_Info GxB_Desc_set(GrB_Descriptor desc, GrB_Desc_Field field, ...);
+extern GrB_Info GxB_Desc_set_FP64(GrB_Descriptor desc, GrB_Desc_Field field, double value);
+extern GrB_Info GxB_Desc_set_INT32(GrB_Descriptor desc, GrB_Desc_Field field, int32_t value);
 extern GrB_Info GxB_Descriptor_fprint(GrB_Descriptor descriptor, const char *name, GxB_Print_Level pr, FILE *f);
 extern GrB_Info GxB_Descriptor_get(GrB_Desc_Value *val, GrB_Descriptor desc, GrB_Desc_Field field);
 
@@ -2996,7 +3000,11 @@ extern void GxB_Matrix_Iterator_getIndex(GxB_Iterator iterator, GrB_Index *row, 
 extern GrB_Info GxB_Col_subassign(GrB_Matrix C, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_Vector u, const GrB_Index *I, GrB_Index ni, GrB_Index j, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_Iterator_attach(GxB_Iterator iterator, GrB_Matrix A, GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_Option_get(GrB_Matrix A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Matrix_Option_get_FP64(GrB_Matrix A, GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Matrix_Option_get_INT32(GrB_Matrix A, GxB_Option_Field field, int32_t *value);
 extern GrB_Info GxB_Matrix_Option_set(GrB_Matrix A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Matrix_Option_set_FP64(GrB_Matrix A, GxB_Option_Field field, double value);
+extern GrB_Info GxB_Matrix_Option_set_INT32(GrB_Matrix A, GxB_Option_Field field, int32_t value);
 extern GrB_Info GxB_Matrix_apply_BinaryOp1st(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Scalar x, const GrB_Matrix A, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_apply_BinaryOp2nd(GrB_Matrix C, const GrB_Matrix Mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Matrix A, const GrB_Scalar y, const GrB_Descriptor desc);
 extern GrB_Info GxB_Matrix_build_Scalar(GrB_Matrix C, const GrB_Index *I, const GrB_Index *J, GrB_Scalar scalar, GrB_Index nvals);
@@ -3156,7 +3164,11 @@ extern GrB_Info GxB_UnaryOp_ztype_name(char *type_name, const GrB_UnaryOp unaryo
 /* vector */
 extern GrB_Info GxB_Vector_Iterator_attach(GxB_Iterator iterator, GrB_Vector v, GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_Option_get(GrB_Vector A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Vector_Option_get_FP64(GrB_Vector v, GxB_Option_Field field, double *value);
+extern GrB_Info GxB_Vector_Option_get_INT32(GrB_Vector v, GxB_Option_Field field, int32_t *value);
 extern GrB_Info GxB_Vector_Option_set(GrB_Vector A, GxB_Option_Field field, ...);
+extern GrB_Info GxB_Vector_Option_set_FP64(GrB_Vector v, GxB_Option_Field field, double value);
+extern GrB_Info GxB_Vector_Option_set_INT32(GrB_Vector v, GxB_Option_Field field, int32_t value);
 extern GrB_Info GxB_Vector_apply_BinaryOp1st(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Scalar x, const GrB_Vector u, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_apply_BinaryOp2nd(GrB_Vector w, const GrB_Vector mask, const GrB_BinaryOp accum, const GrB_BinaryOp op, const GrB_Vector u, const GrB_Scalar y, const GrB_Descriptor desc);
 extern GrB_Info GxB_Vector_build_Scalar(GrB_Vector w, const GrB_Index *I, GrB_Scalar scalar, GrB_Index nvals);


### PR DESCRIPTION
Create our header files from v740 branch of SuiteSparse:GraphBLAS. See: https://github.com/GraphBLAS/python-suitesparse-graphblas/issues/56#issuecomment-1362425096

This will let us avoid use of C variadic args, which we have difficulty supporting across systems.