### PR TITLE
We no longer need suitesparse_graphblas_arm64.h

### DIFF
--- a/suitesparse_graphblas/create_headers.py
+++ b/suitesparse_graphblas/create_headers.py
@@ -799,7 +799,7 @@ def main():
 
     # final files used by cffi (with and without complex numbers)
     final_h = os.path.join(thisdir, "suitesparse_graphblas.h")
-    final_arm64_h = os.path.join(thisdir, "suitesparse_graphblas_arm64.h")
+    # final_arm64_h = os.path.join(thisdir, "suitesparse_graphblas_arm64.h")
     final_no_complex_h = os.path.join(thisdir, "suitesparse_graphblas_no_complex.h")
     source_c = os.path.join(thisdir, "source.c")
 
@@ -827,30 +827,31 @@ def main():
     with open(final_h, "w") as f:
         f.write("\n".join(text) + "\n")
 
-    # Create final header file (arm64)
-    # Replace all variadic arguments (...) with "char *"
-    print(f"Step 4: parse header file to create {final_arm64_h}")
-    orig_text = text
-    patt = re.compile(r"^(extern GrB_Info .*\(.*)(\.\.\.)(\);)$")
-    text = [patt.sub(r"\1char *\3", line) for line in orig_text]
-    with open(final_arm64_h, "w") as f:
-        f.write("\n".join(text) + "\n")
+    # NOTE:suitesparse_graphblas.h and suitesparse_graphblas_arm64.h are the same now
+    # # Create final header file (arm64)
+    # # Replace all variadic arguments (...) with "char *"
+    # print(f"Step 4: parse header file to create {final_arm64_h}")
+    # orig_text = text
+    # patt = re.compile(r"^(extern GrB_Info .*\(.*)(\.\.\.)(\);)$")
+    # text = [patt.sub(r"\1char *\3", line) for line in orig_text]
+    # with open(final_arm64_h, "w") as f:
+    #     f.write("\n".join(text) + "\n")
 
     # Create final header file (no complex)
-    print(f"Step 5: parse header file to create {final_no_complex_h}")
+    print(f"Step 4: parse header file to create {final_no_complex_h}")
     groups_no_complex = parse_header(processed_h, skip_complex=True)
     text = create_header_text(groups_no_complex)
     with open(final_no_complex_h, "w") as f:
         f.write("\n".join(text) + "\n")
 
     # Create source
-    print(f"Step 6: create {source_c}")
+    print(f"Step 5: create {source_c}")
     text = create_source_text(groups)
     with open(source_c, "w") as f:
         f.write("\n".join(text) + "\n")
 
     # Check defines
-    print("Step 7: check #define definitions")
+    print("Step 6: check #define definitions")
     with open(graphblas_h) as f:
         text = f.read()
     define_lines = re.compile(r".*?#define\s+\w+\s+")


### PR DESCRIPTION
Use of `suitesparse_graphblas_arm64.h` and `suitesparse_graphblas_no_complex.h` was removed in #68 (`build.py` was renamed to `build_graphblas_cffi.py` and the logic for which header to use was changed). We no longer need arm64.h b/c it is now the same as the standard header. I believe this change occurred in #58.

Technically, we don't need to generate and keep `suitesparse_graphblas_no_complex.h` either since complex works on Windows now, but maybe it's okay/safer to keep around?