### PR TITLE
Replace INT8 with BOOL for SUITESPARSE_FAST_BUILD

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
-  - repo: https://github.com/myint/autoflake
+  - repo: https://github.com/PyCQA/autoflake
     rev: v2.1.1
     hooks:
       - id: autoflake
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.3.2
     hooks:
       - id: pyupgrade
         args: [--py38-plus]

--- a/suitesparse.sh
+++ b/suitesparse.sh
@@ -67,7 +67,7 @@ if [ -n "${SUITESPARSE_FAST_BUILD}" ]; then
     # Disable optimizing even more types. This is for builds that don't finish in runner resource limits,
     # such as emulated aarm64.
 
-    echo "#define GxB_NO_BOOL      1" >> ../Source/GB_control.h
+#    echo "#define GxB_NO_BOOL      1" >> ../Source/GB_control.h
 #    echo "#define GxB_NO_FP32      1" >> ../Source/GB_control.h
 #    echo "#define GxB_NO_FP64      1" >> ../Source/GB_control.h
     echo "#define GxB_NO_FC32      1" >> ../Source/GB_control.h
@@ -75,7 +75,7 @@ if [ -n "${SUITESPARSE_FAST_BUILD}" ]; then
     echo "#define GxB_NO_INT16     1" >> ../Source/GB_control.h
     echo "#define GxB_NO_INT32     1" >> ../Source/GB_control.h
 #    echo "#define GxB_NO_INT64     1" >> ../Source/GB_control.h
-#    echo "#define GxB_NO_INT8      1" >> ../Source/GB_control.h
+    echo "#define GxB_NO_INT8      1" >> ../Source/GB_control.h
     echo "#define GxB_NO_UINT16    1" >> ../Source/GB_control.h
     echo "#define GxB_NO_UINT32    1" >> ../Source/GB_control.h
     echo "#define GxB_NO_UINT64    1" >> ../Source/GB_control.h


### PR DESCRIPTION
This should hopefully allow aarch64 wheels to build faster in CI.

As discussed in #81.