### PR TITLE
Split macos architectures

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,13 +60,19 @@ jobs:
             manylinux_image: manylinux2014
             cibw_archs: "aarch64"
 
-          # Use x86 macOS runner to build both x86 and ARM.
+          # macOS x86
+          - os: macos-latest
+            python-version: "3.8"
+            platform_id: macosx_x86_64
+            cibw_archs: "x86_64"
+
+          # Use x86 macOS runner to build ARM.
           # GitHub does not offer Apple Silicon yet (only for self-hosted).
           # See https://github.com/github/roadmap/issues/528
           - os: macos-latest
             python-version: "3.8"
             platform_id: macosx_x86_64
-            cibw_archs: "x86_64 arm64"
+            cibw_archs: "arm64"
 
     steps:
       - uses: actions/checkout@v3
@@ -117,7 +123,8 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: CMAKE_GNUtoMS=ON GRAPHBLAS_PREFIX="C:/GraphBLAS"
 
           # macOS libomp requires special configs. BREW_LIBOMP=1 asks suitesparse.sh to include them.
-          CIBW_ENVIRONMENT_MACOS: BREW_LIBOMP="1"
+          # SUITESPARSE_MACOS_ARCH asks to build a particular architecture. Either x86 or arm64.
+          CIBW_ENVIRONMENT_MACOS: BREW_LIBOMP="1" SUITESPARSE_MACOS_ARCH=${{ matrix.cibw_archs }}
 
           # Uncomment to only build CPython wheels
 #          CIBW_BUILD: "cp*"
@@ -143,8 +150,8 @@ jobs:
           # run tests
           CIBW_TEST_COMMAND: "pytest --pyargs suitesparse_graphblas"
 
-          # GitHub Actions macOS Intel runner cannot run ARM tests.
-          CIBW_TEST_SKIP: "*-macosx_arm64"
+          # GitHub Actions macOS Intel runner cannot run ARM tests. Uncomment to silence warning.
+#          CIBW_TEST_SKIP: "*-macosx_arm64"
 
         run: |
           python -m pip install cibuildwheel

--- a/suitesparse.sh
+++ b/suitesparse.sh
@@ -25,8 +25,12 @@ if [ -n "${BREW_LIBOMP}" ]; then
     cmake_params+=(-DOpenMP_libomp_LIBRARY="omp")
     export LDFLAGS="-L$(brew --prefix libomp)/lib"
 
-    # build both x86 and ARM
-    export CFLAGS="-arch x86_64 -arch arm64"
+    if [ -n "${SUITESPARSE_MACOS_ARCH}" ]; then
+        export CFLAGS="-arch ${SUITESPARSE_MACOS_ARCH}"
+    else
+        # build both x86 and ARM
+        export CFLAGS="-arch x86_64 -arch arm64"
+    fi
 fi
 
 if [ -n "${CMAKE_GNUtoMS}" ]; then


### PR DESCRIPTION
Split macOS wheels into separate x86 and arm runners.

This results in wheels that do not include the other architecture in the other wheels.

The universal2 libomp mechanism is retained to keep the arm install name fix in place. When ARM runners are available you can just delete that script and everything should work unchanged.

See https://github.com/GraphBLAS/python-suitesparse-graphblas/issues/81