### PR TITLE
Update to 8.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         os: ["ubuntu-latest"]
         source: ["source"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        graphblas-version: ["8.0.2.beta1"]
+        graphblas-version: ["8.0.2.beta4"]
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        source: ["conda-forge"]
-        # os: ["ubuntu-latest"]
-        # source: ["source"]
+        # os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        # source: ["conda-forge"]
+        os: ["ubuntu-latest"]
+        source: ["source"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        graphblas-version: ["8.0.1"]
+        graphblas-version: ["8.0.2.beta1"]
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -41,22 +41,22 @@ jobs:
       if: (contains(matrix.source, 'source'))
       run: |
         # From release (does not work with beta versions)
-        GRAPHBLAS_PREFIX=${CONDA_PREFIX} bash suitesparse.sh refs/tags/${{ matrix.graphblas-version }}.0
+        # GRAPHBLAS_PREFIX=${CONDA_PREFIX} bash suitesparse.sh refs/tags/${{ matrix.graphblas-version }}.0
 
         # From tag
-        # curl -L https://github.com/DrTimothyAldenDavis/GraphBLAS/archive/refs/tags/v${{ matrix.graphblas-version }}.tar.gz | tar xzf -
-        # pushd GraphBLAS-${{ matrix.graphblas-version }}/build
+        curl -L https://github.com/DrTimothyAldenDavis/GraphBLAS/archive/refs/tags/v${{ matrix.graphblas-version }}.tar.gz | tar xzf -
+        pushd GraphBLAS-${{ matrix.graphblas-version }}/build
 
         # From branch
         # curl -L https://github.com/DrTimothyAldenDavis/GraphBLAS/tarball/${{ matrix.graphblas-version }} | tar xzf -
         # pushd DrTim*/build
 
-        # echo ${CONDA_PREFIX}
-        # cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release ..
-        # cat Makefile
-        # make all JOBS=16
-        # make install
-        # popd
+        echo ${CONDA_PREFIX}
+        cmake -DJITINIT=2 -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release ..
+        cat Makefile
+        make all JOBS=16
+        make install
+        popd
     - name: Build
       run: |
         pip install -e . --no-deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        # source: ["conda-forge"]
-        os: ["ubuntu-latest"]
-        source: ["source"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        source: ["conda-forge"]
+        # os: ["ubuntu-latest"]
+        # source: ["source"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        graphblas-version: ["8.0.2.beta4"]
+        graphblas-version: ["8.0.2"]
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -41,22 +41,22 @@ jobs:
       if: (contains(matrix.source, 'source'))
       run: |
         # From release (does not work with beta versions)
-        # GRAPHBLAS_PREFIX=${CONDA_PREFIX} bash suitesparse.sh refs/tags/${{ matrix.graphblas-version }}.0
+        GRAPHBLAS_PREFIX=${CONDA_PREFIX} bash suitesparse.sh refs/tags/${{ matrix.graphblas-version }}.0
 
         # From tag
-        curl -L https://github.com/DrTimothyAldenDavis/GraphBLAS/archive/refs/tags/v${{ matrix.graphblas-version }}.tar.gz | tar xzf -
-        pushd GraphBLAS-${{ matrix.graphblas-version }}/build
+        # curl -L https://github.com/DrTimothyAldenDavis/GraphBLAS/archive/refs/tags/v${{ matrix.graphblas-version }}.tar.gz | tar xzf -
+        # pushd GraphBLAS-${{ matrix.graphblas-version }}/build
 
         # From branch
         # curl -L https://github.com/DrTimothyAldenDavis/GraphBLAS/tarball/${{ matrix.graphblas-version }} | tar xzf -
         # pushd DrTim*/build
 
-        echo ${CONDA_PREFIX}
-        cmake -DJITINIT=2 -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release ..
-        cat Makefile
-        make all JOBS=16
-        make install
-        popd
+        # echo ${CONDA_PREFIX}
+        # cmake -DJITINIT=2 -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release ..
+        # cat Makefile
+        # make all JOBS=16
+        # make install
+        # popd
     - name: Build
       run: |
         pip install -e . --no-deps

--- a/suitesparse.sh
+++ b/suitesparse.sh
@@ -88,7 +88,9 @@ fi
 # Disable all Source/Generated2 kernels. For workflow development only.
 #cmake_params+=(-DCMAKE_CUDA_DEV=1)
 
-cmake .. -DCMAKE_BUILD_TYPE=Release -G 'Unix Makefiles' "${cmake_params[@]}"
+# Use `-DJITINIT=2` so that the JIT functionality is available, but disabled by default.
+# Level 2, "run", means that pre-JIT kernels may be used, which does not require a compiler at runtime.
+cmake .. -DJITINIT=2 -DCMAKE_BUILD_TYPE=Release -G 'Unix Makefiles' "${cmake_params[@]}"
 make -j$NPROC
 make install
 


### PR DESCRIPTION
Testing out the new `-DJITINIT=2` compile-time option. See: https://github.com/DrTimothyAldenDavis/GraphBLAS/releases/tag/v8.0.2.beta1

This disables JIT by default, but allows the JIT to run pre-compiled kernels and to be enabled.