### PR TITLE
Make PyPy wheels work

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -135,8 +135,11 @@ jobs:
           # Architectures to build specified in matrix
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
-          # No 32-bit builds, no musllinux, no PyPy aarch64 (only due to build speed, numpy does not ship aarch64 pypy wheels)
-          CIBW_SKIP: "*-win32 *_i686 *musl* pp*aarch64"
+          # No 32-bit builds
+          # no musllinux
+          # no PyPy aarch64 (only due to build speed, numpy does not ship aarch64 pypy wheels)
+          # as of writing numpy does not support pypy 3.10
+          CIBW_SKIP: "*-win32 *_i686 *musl* pp*aarch64 pp310*"
 
           # Use delvewheel on Windows.
           # This copies graphblas.dll into the wheel. "repair" in cibuildwheel parlance includes copying any shared

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ requires = [
     "wheel",
     "cffi>=1.11,<1.16",
     "cython",
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; platform_python_implementation != 'PyPy'",
+    # Inspired by SciPy: unpin numpy version for PyPy builds,
+    # as oldest-supported-numpy does not take PyPy into account.
+    "numpy; platform_python_implementation=='PyPy'",
 ]
 
 [project]


### PR DESCRIPTION
Make PyPy wheels work.

* Fix PyPy 3.9 build by following [SciPy's approach](https://github.com/scipy/scipy/blob/main/pyproject.toml). `oldest-supported-numpy` only works for CPython. That same version is unsupported on PyPy. SciPy uses an unpinned numpy version on PyPy  so pip will download a working version.
* Skip PyPy 3.10 because numpy does not support it.
* PyPy 3.8 works by building numpy from source. Since it works, let it be.

Example Actions run (only PyPy enabled in this special run, with a hacked SS version hence why only macOS succeeds): https://github.com/alugowski/python-suitesparse-graphblas/actions/runs/6388091525/job/17337388925