### PR TITLE
Re-enable testing macOS wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -154,9 +154,7 @@ jobs:
           CIBW_TEST_COMMAND: "pytest --pyargs suitesparse_graphblas -s -k test_print_jit_config && pytest -v --pyargs suitesparse_graphblas"
 
           # GitHub Actions macOS Intel runner cannot run ARM tests. Uncomment to silence warning.
-          # CIBW_TEST_SKIP: "*-macosx_arm64"
-          # XXX: tests are failing for macos_x86_64; let's see if we can figure out what's wrong by releasing a broken package... (sorry!)
-          CIBW_TEST_SKIP: "*-macosx_*"
+          CIBW_TEST_SKIP: "*-macosx_arm64"
 
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Tests now pass on cibuildwheel macOS CPython 3.8 through 3.12 and PyPy 3.8. PyPy 3.9 fails, but that's due to an unrelated PyPy build issue fixed by #100.

See example run:
https://github.com/alugowski/python-suitesparse-graphblas/actions/runs/6388465933/job/17338344935

Closes #89