### PR TITLE
Fix Linux Python 3.12 wheel build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         source: ["conda-forge"]
         # os: ["ubuntu-latest"]
         # source: ["source"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         graphblas-version: ["8.2.0"]
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         source: ["conda-forge"]
         # os: ["ubuntu-latest"]
         # source: ["source"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         graphblas-version: ["8.2.0"]
     steps:
     - name: Checkout

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -120,6 +120,9 @@ jobs:
           # Build SuiteSparse
           CIBW_BEFORE_ALL: bash suitesparse.sh ${{ github.ref }}
 
+          # Install FFI dev library, needed for Python 3.12
+          CIBW_BEFORE_BUILD_LINUX: yum install -y libffi-devel
+
           CIBW_ENVIRONMENT_LINUX: SUITESPARSE_FAST_BUILD=${{ env.SUITESPARSE_FAST_BUILD }}
 
           # CMAKE_GNUtoMS=ON asks suitesparse.sh to build libraries in MSVC style on Windows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Intended Audience :: Developers",
     "Intended Audience :: Other Audience",


### PR DESCRIPTION
The Python 3.12 on Linux wheel build process appears to need an additional libffi install. The cibuildwheel docs just happen to use `yum install -y libffi-devel` as an example, and that works well to solve the issue.

This makes Python 3.12 wheels work on all three platforms supported by cibuildwheel (macOS and Windows worked already).

See example run: https://github.com/alugowski/python-suitesparse-graphblas/actions/runs/6388570568/job/17338631246
(The PyPy 3.9 fails are fixed by #100)