### PR TITLE
Test Python 3.12 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         source: ["conda-forge"]
         # os: ["ubuntu-latest"]
         # source: ["source"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         graphblas-version: ["8.2.0"]
     steps:
     - name: Checkout


### PR DESCRIPTION
I think Python 3.12 is available from conda-forge now (if not, we'll keep this as a PR until it is).