### PR TITLE
Add an upload destination input to wheels workflow manual dispatch

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,15 @@ on:
 
   # Enable Run Workflow button in GitHub UI
   workflow_dispatch:
+    inputs:
+      # Manual dispatch allows optional upload of wheels to PyPI
+      upload_dest:
+        type: choice
+        description: Upload wheels to
+        options:
+          - No Upload
+          - PyPI
+          - Test PyPI
 
   push:
     branches: [ main ]
@@ -202,7 +211,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # only upload releases to PyPI
-    if: github.repository == 'GraphBLAS/python-suitesparse-graphblas' && github.event_name == 'release' && github.event.action == 'published'
+    if: github.repository == 'GraphBLAS/python-suitesparse-graphblas' && ((github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_dest != 'No Upload'))
 
     steps:
       - uses: actions/setup-python@v4
@@ -214,14 +223,21 @@ jobs:
           name: artifact
           path: dist
 
+      # Upload to PyPI
       - uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_dest == 'PyPI')
         with:
           # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.
           skip-existing: true
           verbose: true
-          # Real PyPI:
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
-          # Test PyPI:
-          # password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          # repository-url: https://test.pypi.org/legacy/
+      # Upload to Test PyPI
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.upload_dest == 'Test PyPI'
+        with:
+          # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.
+          skip-existing: true
+          verbose: true
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -230,7 +230,7 @@ jobs:
           # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.
           skip-existing: true
           verbose: true
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_TOKEN }}
 
       # Upload to Test PyPI
       - uses: pypa/gh-action-pypi-publish@release/v1
@@ -239,5 +239,5 @@ jobs:
           # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.
           skip-existing: true
           verbose: true
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -239,5 +239,4 @@ jobs:
           # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.
           skip-existing: true
           verbose: true
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Add an input to manual dispatch of the wheel workflow:
![image](https://github.com/GraphBLAS/python-suitesparse-graphblas/assets/2730364/9a0f2c94-3ec7-4921-a4d3-54dd3bd96e03)

Choose between skipping wheel upload, or upload to PyPI or Test PyPI.

Useful if a release run fails for an ephemeral reason and just needs a retry. Just trigger the workflow and specify upload to PyPI.

Also this makes it easier to use Test PyPI for things that don't need to be pushed publicly. This could be testing changes to the PyPI upload process itself, or experiments that shouldn't be public.