### PR TITLE
Add id-token permission for PyPI trusted publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,6 +25,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # For PyPI Trusted Publisher
+  id-token: write
+
 jobs:
   build_sdist:
     name: Build SDist
@@ -225,6 +229,7 @@ jobs:
 
       # Upload to PyPI
       - uses: pypa/gh-action-pypi-publish@release/v1
+        name: Upload to PyPI
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_dest == 'PyPI')
         with:
           # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.
@@ -234,6 +239,7 @@ jobs:
 
       # Upload to Test PyPI
       - uses: pypa/gh-action-pypi-publish@release/v1
+        name: Upload to Test PyPI
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.upload_dest == 'Test PyPI'
         with:
           # PyPI does not allow replacing a file. Without this flag the entire action fails if even a single duplicate exists.


### PR DESCRIPTION
Resolve this error when uploading to PyPI using trusted publishing mechanism:

> Trusted publishing exchange failure: 
OpenID Connect token retrieval failed: GitHub: missing or insufficient OIDC token permissions, the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset
> 
> This generally indicates a workflow configuration error, such as insufficient
permissions. Make sure that your workflow has `id-token: write` configured
at the job level, e.g.:
> 
> ```yaml
> permissions:
>   id-token: write
> ```