### PR TITLE
Simplify download-artifact usage thanks to v4.1 `merge-multiple` input

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -217,10 +217,8 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          path: dist_artifacts
-
-      - name: Flatten artifacts to dist/
-        run: mkdir dist && find dist_artifacts -type f -exec mv {} dist \;
+          path: dist
+          merge-multiple: true
 
       # Upload to PyPI
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Version 4.1 of `download-artifact` action was released today that includes a `merge-multiple` input. This makes the manual flatten step redundant.