### PR TITLE
Move from macos-12 to macos-13 runner

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,7 +85,7 @@ jobs:
 
           # macOS x86
           # Note: keep as old as possible as due to libomp this will be the oldest supported macOS version.
-          - os: macos-12
+          - os: macos-13
             cibw_archs: "x86_64"
 
           # macOS Apple Silicon


### PR DESCRIPTION
GitHub removed macos-12.